### PR TITLE
Add capability to scan methods for keyed instance data generation

### DIFF
--- a/src/main/java/org/mockbukkit/metaminer/keyed/KeyedClassTracker.java
+++ b/src/main/java/org/mockbukkit/metaminer/keyed/KeyedClassTracker.java
@@ -2,6 +2,7 @@ package org.mockbukkit.metaminer.keyed;
 
 import io.leangen.geantyref.GenericTypeReflector;
 import io.papermc.paper.registry.RegistryKey;
+import org.bukkit.Keyed;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
@@ -12,11 +13,11 @@ import java.util.Map;
 public class KeyedClassTracker
 {
 
-	public static Map<RegistryKey<?>, Class<?>> CLASS_REGISTRY_KEY_RELATION = loadClassRegistryKeyRelation();
+	public static Map<RegistryKey<? extends Keyed>, Class<?>> CLASS_REGISTRY_KEY_RELATION = loadClassRegistryKeyRelation();
 
-	private static Map<RegistryKey<?>, Class<?>> loadClassRegistryKeyRelation()
+	private static Map<RegistryKey<? extends Keyed>, Class<?>> loadClassRegistryKeyRelation()
 	{
-		Map<RegistryKey<?>, Class<?>> output = new HashMap<>();
+		Map<RegistryKey<? extends Keyed>, Class<?>> output = new HashMap<>();
 		for (final Field field : RegistryKey.class.getFields())
 		{
 			if (field.getType() == RegistryKey.class)
@@ -25,7 +26,7 @@ public class KeyedClassTracker
 				final Class<?> legacyType = GenericTypeReflector.erase(((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0]);
 				try
 				{
-					RegistryKey<?> registryKey = (RegistryKey<?>) field.get(null);
+					RegistryKey<? extends Keyed> registryKey = (RegistryKey<? extends Keyed>) field.get(null);
 					output.put(registryKey, legacyType);
 				}
 				catch (IllegalAccessException e)

--- a/src/main/java/org/mockbukkit/metaminer/keyed/KeyedDataGenerator.java
+++ b/src/main/java/org/mockbukkit/metaminer/keyed/KeyedDataGenerator.java
@@ -8,6 +8,7 @@ import io.papermc.paper.registry.RegistryKey;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.bukkit.Keyed;
 import org.bukkit.Registry;
+import org.bukkit.generator.structure.Structure;
 import org.bukkit.damage.DamageType;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemType;
@@ -71,6 +72,9 @@ public class KeyedDataGenerator implements DataGenerator
 		if (keyed instanceof Enchantment enchantment)
 		{
 			addEnchantmentProperties(jsonObject, enchantment);
+		}
+		if (keyed instanceof Structure structure){
+			jsonObject.add("type", new JsonPrimitive(structure.getStructureType().getKey().toString()));
 		}
 	}
 

--- a/src/main/java/org/mockbukkit/metaminer/keyed/KeyedDataGenerator.java
+++ b/src/main/java/org/mockbukkit/metaminer/keyed/KeyedDataGenerator.java
@@ -1,32 +1,23 @@
 package org.mockbukkit.metaminer.keyed;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import org.bukkit.JukeboxSong;
 import org.bukkit.Keyed;
-import org.bukkit.block.BlockType;
+import org.bukkit.Registry;
 import org.bukkit.damage.DamageType;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.generator.structure.Structure;
 import org.bukkit.inventory.ItemType;
-import org.bukkit.inventory.meta.trim.TrimMaterial;
-import org.bukkit.inventory.meta.trim.TrimPattern;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 import org.mockbukkit.metaminer.DataGenerator;
 import org.mockbukkit.metaminer.util.JsonUtil;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Writer;
-import java.lang.reflect.Field;
-import java.util.Map;
 
 public class KeyedDataGenerator implements DataGenerator
 {
@@ -46,113 +37,50 @@ public class KeyedDataGenerator implements DataGenerator
 			throw new IOException("Could not make directory: " + this.dataFolder);
 		}
 
-		for (Map.Entry<RegistryKey<?>, Class<?>> entry : KeyedClassTracker.CLASS_REGISTRY_KEY_RELATION.entrySet())
+		for (RegistryKey<? extends Keyed> registryKey : KeyedClassTracker.CLASS_REGISTRY_KEY_RELATION.keySet())
 		{
-
+			Registry<? extends Keyed> registry = RegistryAccess.registryAccess().getRegistry(registryKey);
 			JsonArray array = new JsonArray();
-			Class<?> tClass = entry.getValue();
-			RegistryKey<?> key = entry.getKey();
-
-			for (Field field : tClass.getDeclaredFields())
+			for (Keyed keyed : registry)
 			{
-				JsonObject jsonObject = new JsonObject();
-				try
-				{
-					Object object = field.get(null);
-					if (tClass.isInstance(object))
-					{
-						Keyed keyedObject = (Keyed) object;
-						jsonObject.add("key", new JsonPrimitive(keyedObject.getKey().toString()));
-						if (keyedObject instanceof Structure structure)
-						{
-							jsonObject.add("type", new JsonPrimitive(structure.getStructureType().getKey().toString()));
-						}
-						if (keyedObject instanceof Enchantment enchantment)
-						{
-							addEnchantmentProperties(jsonObject, enchantment);
-						}
-						if (keyedObject instanceof PotionEffectType potionEffectType)
-						{
-							addPotionEffectTypeProperties(jsonObject, potionEffectType);
-						}
-						if (keyedObject instanceof DamageType damageType)
-						{
-							addDamageTypeProperties(jsonObject, damageType);
-						}
-						if (keyedObject instanceof TrimPattern trimPattern)
-						{
-							addTrimPatternProperties(jsonObject, trimPattern);
-						}
-						if (keyedObject instanceof TrimMaterial trimMaterial)
-						{
-							addTrimMaterialProperties(jsonObject, trimMaterial);
-						}
-						if (keyedObject instanceof ItemType itemType)
-						{
-							addItemTypeProperties(jsonObject, itemType);
-						}
-						if (keyedObject instanceof BlockType blockType)
-						{
-							addBlockTypeProperties(jsonObject, blockType);
-						}
-						if (keyedObject instanceof JukeboxSong jukeboxSong)
-						{
-							addJukeboxSongProperties(jsonObject, jukeboxSong);
-						}
-						array.add(jsonObject);
-					}
-				}
-				catch (NullPointerException | IllegalAccessException | IllegalArgumentException ignored)
-				{
-				}
+				JsonObject keyedObjectData = MethodDataScanner.findMethodData(keyed);
+				addNonTrivialData(keyedObjectData, keyed);
+				array.add(keyedObjectData);
 			}
-			File destinationFile = new File(dataFolder, key.key().value() + ".json");
+			File destinationFile = new File(dataFolder, registryKey.key().value() + ".json");
 			JsonObject rootObject = new JsonObject();
 			rootObject.add("values", array);
 			JsonUtil.dump(rootObject, destinationFile);
 		}
 	}
 
-	private void addBlockTypeProperties(JsonObject jsonObject, BlockType blockType)
+	private void addNonTrivialData(JsonObject jsonObject, Keyed keyed)
 	{
-		jsonObject.add("itemType", new JsonPrimitive(blockType.hasItemType()));
-		jsonObject.add("solid", new JsonPrimitive(blockType.isSolid()));
-		jsonObject.add("flammable", new JsonPrimitive(blockType.isFlammable()));
-		jsonObject.add("burnable", new JsonPrimitive(blockType.isBurnable()));
-		jsonObject.add("occluding", new JsonPrimitive(blockType.isOccluding()));
-		jsonObject.add("gravity", new JsonPrimitive(blockType.hasGravity()));
-		jsonObject.add("interactable", new JsonPrimitive(blockType.isInteractable()));
-		jsonObject.add("hardness", new JsonPrimitive(blockType.getHardness()));
-		jsonObject.add("slipperiness", new JsonPrimitive(blockType.getSlipperiness()));
-		jsonObject.add("blastResistance", new JsonPrimitive(blockType.getBlastResistance()));
-		jsonObject.add("air", new JsonPrimitive(blockType.isAir()));
-		jsonObject.add("translationKey", new JsonPrimitive(blockType.getTranslationKey()));
+		if (keyed instanceof ItemType itemType)
+		{
+			addItemTypeProperties(jsonObject, itemType);
+		}
+		if (keyed instanceof DamageType damageType)
+		{
+			addDamageTypeProperties(jsonObject, damageType);
+		}
+		if (keyed instanceof PotionEffectType potionEffectType)
+		{
+			addPotionEffectTypeProperties(jsonObject, potionEffectType);
+		}
+		if (keyed instanceof Enchantment enchantment)
+		{
+			addEnchantmentProperties(jsonObject, enchantment);
+		}
 	}
 
 	private void addItemTypeProperties(JsonObject jsonObject, ItemType itemType)
 	{
-		jsonObject.add("maxStackSize", new JsonPrimitive(itemType.getMaxStackSize()));
-		jsonObject.add("maxDurability", new JsonPrimitive(itemType.getMaxDurability()));
-		jsonObject.add("edible", new JsonPrimitive(itemType.isEdible()));
-		jsonObject.add("record", new JsonPrimitive(itemType.isRecord()));
-		jsonObject.add("fuel", new JsonPrimitive(itemType.isFuel()));
-		jsonObject.add("blockType", new JsonPrimitive(itemType.hasBlockType()));
-		jsonObject.add("translationKey", new JsonPrimitive(itemType.getTranslationKey()));
-		jsonObject.add("material",new JsonPrimitive(itemType.asMaterial().name()));
+		jsonObject.add("material", new JsonPrimitive(itemType.asMaterial().name()));
 		if (itemType != ItemType.AIR)
 		{
 			jsonObject.add("metaClass", new JsonPrimitive(itemType.getItemMetaClass().getSimpleName()));
 		}
-	}
-
-	private void addTrimMaterialProperties(JsonObject jsonObject, TrimMaterial trimMaterial)
-	{
-		jsonObject.add("description", GsonComponentSerializer.gson().serializeToTree(trimMaterial.description()));
-	}
-
-	private void addTrimPatternProperties(JsonObject jsonObject, TrimPattern trimPattern)
-	{
-		jsonObject.add("description", GsonComponentSerializer.gson().serializeToTree(trimPattern.description()));
 	}
 
 	private void addDamageTypeProperties(JsonObject jsonObject, DamageType damageType)
@@ -160,32 +88,16 @@ public class KeyedDataGenerator implements DataGenerator
 		jsonObject.add("damageScaling", new JsonPrimitive(damageType.getDamageScaling().toString()));
 		jsonObject.add("sound", new JsonPrimitive(damageType.getDamageEffect().getSound().getKey().toString()));
 		jsonObject.add("deathMessageType", new JsonPrimitive(damageType.getDeathMessageType().toString()));
-		jsonObject.add("exhaustion", new JsonPrimitive(damageType.getExhaustion()));
 	}
 
 	private void addPotionEffectTypeProperties(JsonObject jsonObject, PotionEffectType potionEffectType)
 	{
-		jsonObject.add("id", new JsonPrimitive(potionEffectType.getId()));
-		jsonObject.add("name", new JsonPrimitive(potionEffectType.getName()));
-		jsonObject.add("instant", new JsonPrimitive(potionEffectType.isInstant()));
 		jsonObject.add("rgb", new JsonPrimitive(potionEffectType.getColor().asRGB()));
 		jsonObject.add("category", new JsonPrimitive(potionEffectType.getEffectCategory().toString()));
 	}
 
-	/**
-	 * Currently not taking the following properties into consideration:
-	 * -
-	 *
-	 * @param jsonObject  <p>The JsonObject to modify</p>
-	 * @param enchantment <p>The enchantment to get the properties from</p>
-	 */
 	private void addEnchantmentProperties(JsonObject jsonObject, Enchantment enchantment)
 	{
-		jsonObject.add("treasure", new JsonPrimitive(enchantment.isTreasure()));
-		jsonObject.add("cursed", new JsonPrimitive(enchantment.isCursed()));
-		jsonObject.add("maxLevel", new JsonPrimitive(enchantment.getMaxLevel()));
-		jsonObject.add("startLevel", new JsonPrimitive(enchantment.getStartLevel()));
-		jsonObject.add("name", new JsonPrimitive(enchantment.getName()));
 		JsonArray displayNames = new JsonArray();
 		JsonArray minModifiedCosts = new JsonArray();
 		JsonArray maxModifiedCosts = new JsonArray();
@@ -210,8 +122,6 @@ public class KeyedDataGenerator implements DataGenerator
 		jsonObject.add("displayNames", displayNames);
 		jsonObject.add("minModifiedCosts", minModifiedCosts);
 		jsonObject.add("maxModifiedCosts", maxModifiedCosts);
-		jsonObject.add("tradeable", new JsonPrimitive(enchantment.isTradeable()));
-		jsonObject.add("discoverable", new JsonPrimitive(enchantment.isDiscoverable()));
 
 		JsonArray conflicts = new JsonArray();
 		for (Enchantment otherEnchantment : Enchantment.values())
@@ -222,13 +132,6 @@ public class KeyedDataGenerator implements DataGenerator
 			}
 		}
 		jsonObject.add("conflicts", conflicts);
-	}
-
-	private void addJukeboxSongProperties(JsonObject jsonObject, JukeboxSong jukeboxSong)
-	{
-		JsonObject description = new JsonObject();
-		description.add("translate", new JsonPrimitive(jukeboxSong.getTranslationKey()));
-		jsonObject.add("description", description);
 	}
 
 }

--- a/src/main/java/org/mockbukkit/metaminer/keyed/MethodDataScanner.java
+++ b/src/main/java/org/mockbukkit/metaminer/keyed/MethodDataScanner.java
@@ -80,6 +80,10 @@ public class MethodDataScanner
 		{
 			return new JsonPrimitive((Float) method.invoke(object));
 		}
+		if (returnType == byte.class)
+		{
+			return new JsonPrimitive((Byte) method.invoke(object));
+		}
 		if (returnType == String.class)
 		{
 			return new JsonPrimitive((String) method.invoke(object));

--- a/src/main/java/org/mockbukkit/metaminer/keyed/MethodDataScanner.java
+++ b/src/main/java/org/mockbukkit/metaminer/keyed/MethodDataScanner.java
@@ -1,0 +1,108 @@
+package org.mockbukkit.metaminer.keyed;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import net.kyori.adventure.key.Keyed;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class MethodDataScanner
+{
+
+	private static final Pattern WORDS_TO_REPLACE = Pattern.compile("((^get)|(^has)|(^is))([A-Z])");
+	private static final Set<String> METHOD_NAME_BLACKLIST = Set.of("hashCode", "toString");
+
+	public static JsonObject findMethodData(Keyed keyed)
+	{
+		Class<? extends Keyed> kClass = keyed.getClass();
+		JsonObject output = new JsonObject();
+		for (Method method : kClass.getMethods())
+		{
+			if (METHOD_NAME_BLACKLIST.contains(method.getName()))
+			{
+				continue;
+			}
+			String simplifiedMethodName = simplifyMethodName(method.getName());
+			if (method.getGenericParameterTypes().length > 0)
+			{
+				continue;
+			}
+			Class<?> returnType = method.getReturnType();
+			try
+			{
+				JsonElement returnValue = getReturnValue(returnType, method, keyed);
+				if (returnValue != null)
+				{
+					output.add(simplifiedMethodName, returnValue);
+				}
+			}
+			catch (Exception ignored)
+			{
+				// Anything can go wrong here, might as well catch anything
+			}
+		}
+		return output;
+	}
+
+	private static @Nullable JsonElement getReturnValue(Class<?> returnType, Method method, Keyed object) throws InvocationTargetException, IllegalAccessException
+	{
+		if (returnType == boolean.class)
+		{
+			return new JsonPrimitive((Boolean) method.invoke(object));
+		}
+		if (returnType == int.class)
+		{
+			return new JsonPrimitive((Integer) method.invoke(object));
+		}
+		if (returnType == short.class)
+		{
+			return new JsonPrimitive((Short) method.invoke(object));
+		}
+		if (returnType == long.class)
+		{
+			return new JsonPrimitive((Long) method.invoke(object));
+		}
+		if (returnType == double.class)
+		{
+			return new JsonPrimitive((Double) method.invoke(object));
+		}
+		if (returnType == float.class)
+		{
+			return new JsonPrimitive((Float) method.invoke(object));
+		}
+		if (returnType == String.class)
+		{
+			return new JsonPrimitive((String) method.invoke(object));
+		}
+		if (returnType.isAssignableFrom(NamespacedKey.class))
+		{
+			return new JsonPrimitive(((NamespacedKey) method.invoke(object)).toString());
+		}
+		if (returnType.isAssignableFrom(Component.class))
+		{
+			return GsonComponentSerializer.gson().serializeToTree((Component) method.invoke(object));
+		}
+		return null;
+	}
+
+	private static String simplifyMethodName(String name)
+	{
+		Matcher matcher = WORDS_TO_REPLACE.matcher(name);
+		if (matcher.find())
+		{
+			return matcher.group(5).toLowerCase(Locale.ROOT) + matcher.replaceAll("");
+		}
+		return name;
+	}
+
+}

--- a/src/main/java/org/mockbukkit/metaminer/keyed/RegistryKeyClassDataGenerator.java
+++ b/src/main/java/org/mockbukkit/metaminer/keyed/RegistryKeyClassDataGenerator.java
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import io.papermc.paper.registry.RegistryKey;
+import org.bukkit.Keyed;
 import org.mockbukkit.metaminer.DataGenerator;
 import org.mockbukkit.metaminer.util.JsonUtil;
 
@@ -30,7 +31,7 @@ public class RegistryKeyClassDataGenerator implements DataGenerator
 		File destinationFile = new File(dataFolder, "registry_key_class_relation.json");
 		JsonObject rootObject = new JsonObject();
 
-		for (Map.Entry<RegistryKey<?>, Class<?>> entry : KeyedClassTracker.CLASS_REGISTRY_KEY_RELATION.entrySet())
+		for (Map.Entry<RegistryKey<? extends Keyed>, Class<?>> entry : KeyedClassTracker.CLASS_REGISTRY_KEY_RELATION.entrySet())
 		{
 			rootObject.add(entry.getKey().key().asString(), new JsonPrimitive(entry.getValue().getName()));
 		}


### PR DESCRIPTION
I moved some trivial data that could be fetched from keyed instances to a method scanner which does everything automatically.

## Why
Too much time has been taken into maintaining keyed classes, this should simplify the process of generating the data for each keyed class a lot.

## What does it do
For example, let's say you have a method `boolean isSomething()` that returns `true`, then the method scanner would interpret that method as the following json:
```json
{
    ...
    "something": true
    ...
}
```
The method name becomes a key, where `^is`, `^get`, `^has` is replaced with nothing.

## Capabilities
It's currently able to parse the following return types:
- boolean
- float
- double
- long
- int
- short
- byte
- String
- NamespacedKey
- Component (kyori)